### PR TITLE
Fixing rubyenv-installer path

### DIFF
--- a/bin/ruby-installer.sh
+++ b/bin/ruby-installer.sh
@@ -6,7 +6,7 @@ export RUBY_VERSION="2.0.0-p353"
 
 if [ ! -d "${RBENV_ROOT}" ] ; then
 
-    curl https://raw.github.com/fesplugas/rbenv-installer/master/bin/rbenv-installer | bash
+    curl https://raw.githubusercontent.com/fesplugas/rbenv-installer/master/bin/rbenv-installer | bash
 
     echo "gem: --no-rdoc --no-ri" > ${OPENSHIFT_DATA_DIR}.gemrc
 


### PR DESCRIPTION
It looks like github's URL for raw file was updated, here is the current one